### PR TITLE
Add Linguist override for .vb files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.vb    linguist-language=vba


### PR DESCRIPTION
I noticed that you use the `.vb` extension for most of your VBA code. However, this extension is marked by [Linguist](https://github.com/github/linguist) as a `Visual Basic .NET` extension. To fix that, I've added an override to your `.gitattributes` file.

This way, the repo can be properly recognized as a VBA repo on GitHub (mainly in the languages breakdown and in searches).

Alternatively, you could change the extensions of the files to `.vba` (or maybe `.bas`) to get a similar result.